### PR TITLE
feat(config): support environment variables for ShotGrid credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,79 @@ This project provides an MCP (Model Context Protocol) server, implemented using 
 - [httpx-auth](https://pypi.org/project/httpx-auth/)
 - [mcp.server.fastmcp](https://github.com/modelcontextprotocol/fastmcp)
 
-## Usage
+## Installation
 
-1. **Set up ShotGrid credentials**:
-   - Obtain your ShotGrid host URL, client ID, and client secret.
-
-2. **Run the server** (replace placeholders with your actual values):
+1. **Clone the repository:**
 
    ```bash
-   uv run --directory {REPO_DIR} main.py -host https://your-shotgrid-url -ci your_client_id -cs your_client_secret
+   git clone https://github.com/chordee/mcp-server-shotgrid.git
    ```
 
-   All three arguments are required. Both short (`-host`, `-ci`, `-cs`) and long (`--host`, `--client-id`, `--client-secret`) forms are supported.
+2. **Install [uv](https://docs.astral.sh/uv/)** if you don't have it. `uv` manages Python 3.11 and the dependencies declared in `pyproject.toml` automatically; no manual `venv` step is needed.
 
-   The server uses FastMCP and communicates via `transport="stdio"` only.
+3. **Configure credentials.** Use environment variables (recommended) or CLI arguments. See [Usage](#usage).
 
-3. **Integrate with your LLM agent**:
-   - The server exposes tools via MCP for LLMs to call.
+4. **Register the server with your MCP client.** Example for Claude Code (`~/.claude.json` or a project-local `.mcp.json`):
+
+   ```json
+   {
+     "mcpServers": {
+       "shotgrid": {
+         "command": "uv",
+         "args": ["run", "--directory", "D:\\path\\to\\mcp-server-shotgrid", "main.py"],
+         "env": {
+           "SHOTGRID_HOST": "https://your-shotgrid-url",
+           "SHOTGRID_CLIENT_ID": "your_client_id",
+           "SHOTGRID_CLIENT_SECRET": "your_client_secret"
+         }
+       }
+     }
+   }
+   ```
+
+## Usage
+
+Credentials can come from either **environment variables (recommended)** or CLI arguments. Environment variables take precedence; if both are missing for any of the three values, the server exits with an error.
+
+### Option A — Environment variables (recommended)
+
+| Variable | Description |
+|---|---|
+| `SHOTGRID_HOST` | ShotGrid host URL, e.g. `https://your-shotgrid-url` |
+| `SHOTGRID_CLIENT_ID` | OAuth2 client ID |
+| `SHOTGRID_CLIENT_SECRET` | OAuth2 client secret |
+
+**Windows (PowerShell):**
+
+```powershell
+$env:SHOTGRID_HOST = "https://your-shotgrid-url"
+$env:SHOTGRID_CLIENT_ID = "your_client_id"
+$env:SHOTGRID_CLIENT_SECRET = "your_client_secret"
+uv run --directory C:\path\to\mcp-server-shotgrid main.py
+```
+
+**macOS / Linux (bash / zsh):**
+
+```bash
+export SHOTGRID_HOST="https://your-shotgrid-url"
+export SHOTGRID_CLIENT_ID="your_client_id"
+export SHOTGRID_CLIENT_SECRET="your_client_secret"
+uv run --directory /path/to/mcp-server-shotgrid main.py
+```
+
+### Option B — CLI arguments
+
+```bash
+uv run --directory {REPO_DIR} main.py --host https://your-shotgrid-url --client-id your_client_id --client-secret your_client_secret
+```
+
+Both short (`-host`, `-ci`, `-cs`) and long (`--host`, `--client-id`, `--client-secret`) forms are supported.
+
+### Security note
+
+Prefer environment variables over CLI arguments. Arguments passed on the command line are visible in process listings (`ps`, Task Manager), shell history, and many supervisor/IDE configuration files. Environment variables set inside the MCP client config (such as Claude Code's `.mcp.json`) are not exposed to other users on the host.
+
+The server uses FastMCP and communicates via `transport="stdio"` only. Tools exposed by MCP are available for LLM agents to call.
 
 ## Available Tools
 
@@ -62,21 +118,12 @@ All tools are asynchronous and exposed via FastMCP. They return structured Pytho
 
 The server includes a robust error handling wrapper that captures ShotGrid API errors and internal exceptions, returning them as structured JSON objects with `error` and `message` fields.
 
-## Example
-
-```bash
-uv run --directory {REPO_DIR} main.py --host https://your-shotgrid-url --client-id your_client_id --client-secret your_client_secret
-```
-
 ## Notes
 
 - Ensure your ShotGrid account has API access enabled.
 - The server uses OAuth2 for authentication.
 - The server is implemented using FastMCP and runs with `transport="stdio"` only.
-- Command-line arguments:  
-  - `-host` or `--host` (ShotGrid host URL)  
-  - `-ci` or `--client-id` (OAuth2 client ID)  
-  - `-cs` or `--client-secret` (OAuth2 client secret)
+- Credentials can be provided via environment variables (`SHOTGRID_HOST`, `SHOTGRID_CLIENT_ID`, `SHOTGRID_CLIENT_SECRET`) or CLI arguments (`-host` / `--host`, `-ci` / `--client-id`, `-cs` / `--client-secret`). Env vars take precedence.
 - Some tools use dynamic field fetching and exclude certain keys (see `remove_exclude_fields` in `main.py`).
 - Extend or customize the tools in `main.py` as needed for your workflow.
 - The ShotGrid REST API logic is implemented in `shotgrid_rest.py`.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Both short (`-host`, `-ci`, `-cs`) and long (`--host`, `--client-id`, `--client-
 
 ### Security note
 
-Prefer environment variables over CLI arguments. Arguments passed on the command line are visible in process listings (`ps`, Task Manager), shell history, and many supervisor/IDE configuration files. Environment variables set inside the MCP client config (such as Claude Code's `.mcp.json`) are not exposed to other users on the host.
+Prefer environment variables over CLI arguments. Arguments passed on the command line are visible in process listings (`ps`, Task Manager), shell history, and many supervisor/IDE configuration files. Environment variables can reduce accidental exposure, but they are still secrets — store them in protected config files (for example, `.mcp.json` / `~/.claude.json`), use strict file permissions, and never commit secrets to version control.
 
 The server uses FastMCP and communicates via `transport="stdio"` only. Tools exposed by MCP are available for LLM agents to call.
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import httpx
 from mcp.server.fastmcp import FastMCP
 from typing import List, Dict, Optional, Any, Union
@@ -631,12 +632,30 @@ async def get_entity_by_id(entity_type: ALL_ENTITY_TYPES, entity_id: int) -> Uni
 register_booking_tools(mcp, SG)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="MCP Server for ShotGrid")
-    parser.add_argument("-host", "--host", type=str, help="host address", required=True)
-    parser.add_argument("-ci", "--client-id", type=str, help="client-id", required=True)
-    parser.add_argument("-cs", "--client-secret", type=str, help="client-secret", required=True)
+    parser = argparse.ArgumentParser(
+        description=(
+            "MCP Server for ShotGrid. Credentials can be supplied via "
+            "environment variables (SHOTGRID_HOST, SHOTGRID_CLIENT_ID, "
+            "SHOTGRID_CLIENT_SECRET) or CLI arguments. Env vars take precedence."
+        )
+    )
+    parser.add_argument("-host", "--host", type=str, help="ShotGrid host URL (env: SHOTGRID_HOST)")
+    parser.add_argument("-ci", "--client-id", type=str, help="OAuth2 client ID (env: SHOTGRID_CLIENT_ID)")
+    parser.add_argument("-cs", "--client-secret", type=str, help="OAuth2 client secret (env: SHOTGRID_CLIENT_SECRET)")
     args = parser.parse_args()
-    
-    SG.set_host(args.host)
-    SG.access_token(client_id=args.client_id, client_secret=args.client_secret)
+
+    host = os.environ.get("SHOTGRID_HOST") or args.host
+    client_id = os.environ.get("SHOTGRID_CLIENT_ID") or args.client_id
+    client_secret = os.environ.get("SHOTGRID_CLIENT_SECRET") or args.client_secret
+
+    missing = [name for name, value in (
+        ("host (SHOTGRID_HOST or --host)", host),
+        ("client_id (SHOTGRID_CLIENT_ID or --client-id)", client_id),
+        ("client_secret (SHOTGRID_CLIENT_SECRET or --client-secret)", client_secret),
+    ) if not value]
+    if missing:
+        parser.error("Missing required credentials: " + ", ".join(missing))
+
+    SG.set_host(host)
+    SG.access_token(client_id=client_id, client_secret=client_secret)
     mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary

Adds `SHOTGRID_HOST` / `SHOTGRID_CLIENT_ID` / `SHOTGRID_CLIENT_SECRET` as the preferred way to pass credentials. CLI arguments remain supported as a fallback for backwards compatibility.

**Motivation:** arguments on the command line leak into process listings (`ps`, Task Manager), shell history, supervisor units, and many IDE config files. Environment variables set inside the MCP client config (e.g. Claude Code's `.mcp.json` `env` block) are not exposed to other users on the host.

**Not a breaking change** — existing setups using `--host` / `--client-id` / `--client-secret` continue to work. Recommended next tag: `v0.3.0` (minor bump for the new feature + README expansion).

## Behaviour

- Env vars take precedence; missing env vars fall back to CLI args.
- CLI args are no longer required individually; startup validates that each of the three values resolves from at least one source.
- If any value is missing from both sources, the server exits with argparse's standard error code 2 and a message listing the missing values.

## README updates

- **New `Installation` section** with clone, uv requirement, and an MCP client config example (`.mcp.json`) that shows the `env` block.
- **`Usage` rewritten** to cover the env-var path (recommended) and CLI path, with PowerShell and bash/zsh examples, plus a security note explaining why env vars are preferred.
- **`Example` removed** (merged into Usage).
- **`Notes` updated** to mention the env-var alternative.

## Test plan

Verified end-to-end with a subprocess harness across 7 scenarios:

- [x] `--help` works without any credentials and mentions the env vars
- [x] No env + no args → exit 2, stderr lists all three missing values
- [x] env `SHOTGRID_HOST` only → exit 2, stderr lists missing client_id and client_secret (and does **not** list host as missing)
- [x] CLI `--host` only → same as above, validates the symmetric fallback
- [x] All three env vars set → server starts (credentials resolved)
- [x] All three CLI args, no env → server starts (fallback path)
- [x] Mixed: env `SHOTGRID_HOST` + CLI `--client-id` / `--client-secret` → server starts (resolution merges sources)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for supplying ShotGrid credentials via environment variables, with CLI arguments as a fallback and startup validation that required credentials are present.

* **Documentation**
  * Expanded installation and usage guide with environment-variable vs CLI instructions, precedence rules, platform-specific shell examples, and an MCP client registration example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chordee/mcp-server-shotgrid/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->